### PR TITLE
Replace absolute path to python with \%PYTHONHOME\%.

### DIFF
--- a/Source/BuildAllExes.bat
+++ b/Source/BuildAllExes.bat
@@ -1,6 +1,9 @@
 @echo off
 REM Make sure to use 32 bit python for this so it runs on all machines
-C:\Utils\Python\Python32-34\python ./BuildPrjExeSetup.py py2exe
-C:\Utils\Python\Python32-34\python ./BuildEditorApiExeSetup.py py2exe
-C:\Utils\Python\Python32-34\python ./BuildReleaseManifesterUpdaterExeSetup.py py2exe
-C:\Utils\Python\Python32-34\python ./BuildOpenInVisualStudio.py py2exe
+%PYTHONHOME%\python ./BuildPrjExeSetup.py py2exe
+%PYTHONHOME%\python ./BuildEditorApiExeSetup.py py2exe
+%PYTHONHOME%\python ./BuildReleaseManifesterUpdaterExeSetup.py py2exe
+%PYTHONHOME%\python ./BuildOpenInVisualStudio.py py2exe
+
+
+


### PR DESCRIPTION
Batch file for building Projeny had called python by absolute path, i guess use ENV var more handy.
Note: %PYTHONHOME% isn't set by default so i made it manually.