### PR TITLE
Add 'targetPlatforms' key to internal config representation

### DIFF
--- a/UnityPlugin/Projeny/Main/Serialization/PrjSerializer.cs
+++ b/UnityPlugin/Projeny/Main/Serialization/PrjSerializer.cs
@@ -311,6 +311,12 @@ namespace Projeny.Internal
                 get;
                 set;
             }
+
+            public List<string> TargetPlatforms
+            {
+                get;
+                set;
+            }
         }
 
         class PackageInstallInfoInternal


### PR DESCRIPTION
Otherwise unity plugin's parser prevents using gui package manager.