### PR TITLE
Added platform names to the Change Project menu.

### DIFF
--- a/Projeny.yaml
+++ b/Projeny.yaml
@@ -1,7 +1,7 @@
 # Default values
 # These can all be overriden by user config files
 
-MaxProjectNameLength: 10
+MaxProjectNameLength: 64 
 
 # Set to true if you don't want to use the Projeny editor DLL and instead want to link directly
 # to UnityPlugin\Projeny

--- a/Source/mtm/util/PlatformUtil.py
+++ b/Source/mtm/util/PlatformUtil.py
@@ -17,16 +17,13 @@ def fromPlatformFolderName(platformDirName):
 
 def fromPlatformArgName(platformArgStr):
 
-    if platformArgStr == 'win':
+    if platformArgStr == 'win' or platformArgStr == 'w':
         return Platforms.Windows
-
-    if platformArgStr == 'webp':
-        return Platforms.WebPlayer
 
     if platformArgStr == 'webgl':
         return Platforms.WebGl
 
-    if platformArgStr == 'and':
+    if platformArgStr == 'and' or platformArgStr == 'a':
         return Platforms.Android
 
     if platformArgStr == 'osx':

--- a/Source/mtm/util/PlatformUtil.py
+++ b/Source/mtm/util/PlatformUtil.py
@@ -20,19 +20,19 @@ def fromPlatformArgName(platformArgStr):
     if platformArgStr == 'win' or platformArgStr == 'w':
         return Platforms.Windows
 
-    if platformArgStr == 'webgl':
+    if platformArgStr == 'webgl' or platformArgStr == 'g':
         return Platforms.WebGl
 
     if platformArgStr == 'and' or platformArgStr == 'a':
         return Platforms.Android
 
-    if platformArgStr == 'osx':
+    if platformArgStr == 'osx' or platformArgStr == 'o':
         return Platforms.OsX
 
-    if platformArgStr == 'ios':
+    if platformArgStr == 'ios' or platformArgStr == 'i':
         return Platforms.Ios
 
-    if platformArgStr == 'lin':
+    if platformArgStr == 'lin' or platformArgStr == 'l':
         return Platforms.Linux
 
     assertThat(False)

--- a/Source/mtm/util/Platforms.py
+++ b/Source/mtm/util/Platforms.py
@@ -1,11 +1,10 @@
 
 class Platforms:
     Windows = 'Windows'
-    WebPlayer = 'WebPlayer'
     Android = 'Android'
     WebGl = 'WebGL'
     OsX = 'OSX'
     Linux = 'Linux'
     Ios = 'iOS'
-    All = [Windows, WebPlayer, Android, WebGl, OsX, Linux, Ios]
+    All = [Windows, Android, WebGl, OsX, Linux, Ios]
 

--- a/Source/mtm/util/UnityHelper.py
+++ b/Source/mtm/util/UnityHelper.py
@@ -58,9 +58,6 @@ class UnityHelper:
         if platform == Platforms.Windows:
             return 'win32'
 
-        if platform == Platforms.WebPlayer:
-            return 'web'
-
         if platform == Platforms.Android:
             return 'android'
 

--- a/Source/prj/main/EditorApi.py
+++ b/Source/prj/main/EditorApi.py
@@ -65,8 +65,11 @@ class Runner:
         self._packageMgr.setPathsForProjectPlatform(self._project, self._platform)
 
         if self._requestId == 'updateLinks':
+            isInit = self._packageMgr.isProjectPlatformInitialized(self._project, self._platform)
             self._packageMgr.updateProjectJunctions(self._project, self._platform)
-
+            if not isInit:
+                self._packageMgr.updateLinksForAllProjects()
+        
         elif self._requestId == 'openUnity':
             self._packageMgr.checkProjectInitialized(self._project, self._platform)
             self._unityHelper.openUnity(self._project, self._platform)

--- a/Source/prj/main/Prj.py
+++ b/Source/prj/main/Prj.py
@@ -52,7 +52,7 @@ def addArguments(parser):
     # Core
     parser.add_argument('-in', '--init', action='store_true', help='Initializes the directory links for all projects')
     parser.add_argument('-p', '--project', metavar='PROJECT_NAME', type=str, help="The project to apply changes to.  If unspecified, this will be set to the value for DefaultProject in {0}".format(ConfigFileName))
-    parser.add_argument('-pl', '--platform', type=str, default='win', choices=['win', 'webp', 'webgl', 'and', 'osx', 'ios', 'lin'], help='The platform to use.  If unspecified, windows is assumed.')
+    parser.add_argument('-pl', '--platform', type=str, default='win', choices=['win', 'webgl', 'and', 'osx', 'ios', 'lin'], help='The platform to use.  If unspecified, windows is assumed.')
 
     # Script settinsg
     parser.add_argument('-cfg', '--configPath', metavar='CONFIG_PATH', type=str, help="The path to the _main {0} config file.  If unspecified, it will be assumed to exist at [CurrentDirectory]/{0}".format(ConfigFileName))

--- a/Source/prj/main/Prj.py
+++ b/Source/prj/main/Prj.py
@@ -212,6 +212,7 @@ def _createConfig():
     unityProjectsDir = os.path.join(curDir, 'UnityProjects')
     os.makedirs(unityProjectsDir)
 
+    #Template for Projeny.yaml
     with open(mainConfigPath, 'w', encoding='utf-8') as outFile:
         outFile.write(
 """
@@ -228,6 +229,7 @@ PathVars:
 
     projectGlobalConfigPath = os.path.join(unityProjectsDir, ProjectConfigFileName)
 
+    # Template for UnityProjects ProjenyProject.yaml
     with open(projectGlobalConfigPath, 'w', encoding='utf-8') as outFile:
         outFile.write(
 """
@@ -236,6 +238,9 @@ PathVars:
 # See documentation for the full list of configuration settings
 
 PackageFolders:
+    # Put packages that are used in multiple projeny's here
+    # specify the ProjenyPackagesDir in PathVars in your root directory Projeny.yaml
+    - '[ProjenyPackagesDir]'
     # Put packages that are used in multiple projects here
     - '[SharedUnityPackagesDir]'
     # [ProjectRoot] refers to the folder at UnityProjects/YourProjectName

--- a/Source/prj/main/Prj.py
+++ b/Source/prj/main/Prj.py
@@ -52,7 +52,7 @@ def addArguments(parser):
     # Core
     parser.add_argument('-in', '--init', action='store_true', help='Initializes the directory links for all projects')
     parser.add_argument('-p', '--project', metavar='PROJECT_NAME', type=str, help="The project to apply changes to.  If unspecified, this will be set to the value for DefaultProject in {0}".format(ConfigFileName))
-    parser.add_argument('-pl', '--platform', type=str, default='win', choices=['win', 'webgl', 'and', 'osx', 'ios', 'lin'], help='The platform to use.  If unspecified, windows is assumed.')
+    parser.add_argument('-pl', '--platform', type=str, default='win', choices=['w', 'win', 'g', 'webgl', 'a', 'and', 'o', 'osx', 'i', 'ios', 'l', 'lin'], help='The platform to use.  If unspecified, windows is assumed.')
 
     # Script settinsg
     parser.add_argument('-cfg', '--configPath', metavar='CONFIG_PATH', type=str, help="The path to the _main {0} config file.  If unspecified, it will be assumed to exist at [CurrentDirectory]/{0}".format(ConfigFileName))

--- a/Source/prj/main/PrjRunner.py
+++ b/Source/prj/main/PrjRunner.py
@@ -7,6 +7,7 @@ from mtm.util.Assert import *
 import mtm.util.MiscUtil as MiscUtil
 import mtm.util.PlatformUtil as PlatformUtil
 
+
 from mtm.util.Platforms import Platforms
 from mtm.util.CommonSettings import ConfigFileName
 
@@ -75,7 +76,7 @@ class PrjRunner:
             self._packageMgr.deleteProject(self._args.project)
 
         if self._args.createProject:
-            self._packageMgr.createProject(self._args.project)
+            self._packageMgr.createProject(self._args.project, self._platform)
 
         if self._args.projectAddPackageAssets:
             self._projectConfigChanger.addPackage(self._args.project, self._args.projectAddPackageAssets, True)
@@ -142,6 +143,7 @@ class PrjRunner:
             self._packageMgr.listAllPackages(self._args.project)
 
         if self._args.openUnity:
+            return
             self._packageMgr.checkProjectInitialized(self._args.project, self._platform)
             self._unityHelper.openUnity(self._args.project, self._platform)
 

--- a/Source/prj/main/PrjRunner.py
+++ b/Source/prj/main/PrjRunner.py
@@ -143,7 +143,6 @@ class PrjRunner:
             self._packageMgr.listAllPackages(self._args.project)
 
         if self._args.openUnity:
-            return
             self._packageMgr.checkProjectInitialized(self._args.project, self._platform)
             self._unityHelper.openUnity(self._args.project, self._platform)
 

--- a/Source/prj/main/ProjectSchemaLoader.py
+++ b/Source/prj/main/ProjectSchemaLoader.py
@@ -99,7 +99,7 @@ class ProjectSchemaLoader:
 
         self._ensureAllPackagesExist(packageMap)
 
-        return ProjectSchema(name, packageMap, config.solutionFolders, config.projectSettingsPath)
+        return ProjectSchema(name, packageMap, config.solutionFolders, config.projectSettingsPath, platform, config.targetPlatforms)
 
     def _shouldIncludeForPlatform(self, packageName, packageConfig, folderType, platform):
 
@@ -438,11 +438,13 @@ class PackageReference:
         self.sourceDesc = sourceDesc
 
 class ProjectSchema:
-    def __init__(self, name, packages, customFolderMap, projectSettingsPath):
+    def __init__(self, name, packages, customFolderMap, projectSettingsPath, platform, targetPlatforms):
         self.name = name
         self.packages = packages
         self.customFolderMap = customFolderMap
         self.projectSettingsPath = projectSettingsPath
+        self.platform = platform
+        self.targetPlatforms = targetPlatforms
 
 class FolderTypes:
     Normal = "normal"

--- a/Source/prj/main/VisualStudioHelper.py
+++ b/Source/prj/main/VisualStudioHelper.py
@@ -35,7 +35,9 @@ class VisualStudioHelper:
         try:
             vsPath = self._varMgr.expand('[VisualStudioIdePath]')
 
-            if 'Visual Studio 14.0' in vsPath:
+            if '2017' in vsPath:
+                dte = win32com.client.GetActiveObject("VisualStudio.DTE.15.0")
+            elif 'Visual Studio 14.0' in vsPath:
                 dte = win32com.client.GetActiveObject("VisualStudio.DTE.14.0")
             elif 'Visual Studio 12.0' in vsPath:
                 dte = win32com.client.GetActiveObject("VisualStudio.DTE.12.0")

--- a/Source/prj/main/VisualStudioHelper.py
+++ b/Source/prj/main/VisualStudioHelper.py
@@ -35,7 +35,7 @@ class VisualStudioHelper:
         try:
             vsPath = self._varMgr.expand('[VisualStudioIdePath]')
 
-            if '2017' in vsPath:
+            if '2017' in vsPath or 'Visual Studio 15.0' in vsPath:
                 dte = win32com.client.GetActiveObject("VisualStudio.DTE.15.0")
             elif 'Visual Studio 14.0' in vsPath:
                 dte = win32com.client.GetActiveObject("VisualStudio.DTE.14.0")

--- a/Source/prj/reg/UnityPackageExtractor.py
+++ b/Source/prj/reg/UnityPackageExtractor.py
@@ -80,7 +80,7 @@ class UnityPackageExtractor:
 
     def _isSpecialFolderName(self, dirName):
         dirNameLower = dirName.lower()
-        return dirNameLower == 'editor' or dirNameLower == 'streamingassets' or dirNameLower == 'webplayertemplates'
+        return dirNameLower == 'editor' or dirNameLower == 'streamingassets'
 
     def _chooseDirToCopy(self, startDir):
         rootNames = [x for x in self._sys.walkDir(startDir) if not x.endswith('.meta')]

--- a/UnityPlugin/Projeny/Main/PrjHelper.cs
+++ b/UnityPlugin/Projeny/Main/PrjHelper.cs
@@ -59,19 +59,20 @@ namespace Projeny
             return true;
         }
 
-        public static void ChangeProject(string projectName)
+        public static void ChangeProject(string projectName, string platformName = "windows")
         {
             if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
             {
                 // They hit cancel in the save dialog
                 return;
             }
+            var platform = ProjenyEditorUtil.FromPlatformDirStr(platformName);
 
-            var result = PrjInterface.RunPrj(PrjInterface.CreatePrjRequestForProject("updateLinks", projectName));
+            var result = PrjInterface.RunPrj(PrjInterface.CreatePrjRequestForProjectAndPlatform("updateLinks", projectName, platform));
 
             if (result.Succeeded)
             {
-                result = PrjInterface.RunPrj(PrjInterface.CreatePrjRequestForProject("openUnity", projectName));
+                result = PrjInterface.RunPrj(PrjInterface.CreatePrjRequestForProjectAndPlatform("openUnity", projectName, platform));
 
                 if (result.Succeeded)
                 {

--- a/UnityPlugin/Projeny/Main/PrjInterface.cs
+++ b/UnityPlugin/Projeny/Main/PrjInterface.cs
@@ -296,10 +296,6 @@ namespace Projeny
                 {
                     return "android";
                 }
-                case BuildTarget.WebPlayer:
-                {
-                    return "webplayer";
-                }
                 case BuildTarget.WebGL:
                 {
                     return "webgl";

--- a/UnityPlugin/Projeny/Main/ProjenyEditorMenu.cs
+++ b/UnityPlugin/Projeny/Main/ProjenyEditorMenu.cs
@@ -85,16 +85,16 @@ namespace Projeny
             PrjHelper.ChangePlatform(BuildTarget.StandaloneWindows);
         }
 
-        [MenuItem("Projeny/Change Platform/Webplayer", false, 7)]
-        public static void ChangePlatformWebplayer()
-        {
-            PrjHelper.ChangePlatform(BuildTarget.WebPlayer);
-        }
-
         [MenuItem("Projeny/Change Platform/Android", false, 7)]
         public static void ChangePlatformAndroid()
         {
             PrjHelper.ChangePlatform(BuildTarget.Android);
+        }
+
+        [MenuItem("Projeny/Change Platform/iOS", false, 7)]
+        public static void ChangePlatformIos()
+        {
+            PrjHelper.ChangePlatform(BuildTarget.iOS);
         }
 
         [MenuItem("Projeny/Change Platform/Web GL", false, 7)]
@@ -113,12 +113,6 @@ namespace Projeny
         public static void ChangePlatformLinux()
         {
             PrjHelper.ChangePlatform(BuildTarget.StandaloneLinux);
-        }
-
-        [MenuItem("Projeny/Change Platform/iOS", false, 7)]
-        public static void ChangePlatformIos()
-        {
-            PrjHelper.ChangePlatform(BuildTarget.iOS);
         }
     }
 }

--- a/UnityPlugin/Projeny/Main/ProjenyEditorUtil.cs
+++ b/UnityPlugin/Projeny/Main/ProjenyEditorUtil.cs
@@ -121,10 +121,6 @@ namespace Projeny
                 {
                     return BuildTarget.Android;
                 }
-                case "webplayer":
-                {
-                    return BuildTarget.WebPlayer;
-                }
                 case "webgl":
                 {
                     return BuildTarget.WebGL;


### PR DESCRIPTION
When a new platform is generated for a project, the ProjenyProject.yaml file in the root directory of each project is updated with the target platform, and ProjenyChangeProjectMenu.cs is regenerated for all project/platform combinations.  

The "Projeny/Change Menu" will list all "Project-Platform" combinations to allow switching between projects and a specific platform.  The current behavior defaults to the current platform of the current project for the new project.  

With the new change you could, for example, switch between Project1-Windows and Project2-Android  without having to initialize a Project1-Android or Project2-Windows project, which saves time and space.

I've also removed WebPlayer references, added support for Visual Studio 2017 RC, and reorganized the Change Platform Menu since I primarily dev for mobile and work on windows.  Please cherry pick the changes that make sense for everyone.