### PR TITLE
Fix #69 (git branch switching issue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ project_root_marker
 
 *.csproj.user
 *.suo
+
+**/.vs/
+**/.vscode/

--- a/Source/prj/main/Prj.py
+++ b/Source/prj/main/Prj.py
@@ -25,6 +25,7 @@ from mtm.util.ScriptRunner import ScriptRunner
 from mtm.util.CommonSettings import CommonSettings
 from prj.reg.UnityPackageExtractor import UnityPackageExtractor
 from prj.reg.UnityPackageAnalyzer import UnityPackageAnalyzer
+from prj.main.UnityEditorMenuGenerator import UnityEditorMenuGenerator
 
 import traceback
 
@@ -149,6 +150,7 @@ def installBindings(mainConfigPath):
     Container.bind('UnityPackageAnalyzer').toSingle(UnityPackageAnalyzer)
     Container.bind('ProjectConfigChanger').toSingle(ProjectConfigChanger)
     Container.bind('PrjRunner').toSingle(PrjRunner)
+    Container.bind('UnityEditorMenuGenerator').toSingle(UnityEditorMenuGenerator)
 
     Container.bind('ReleaseSourceManager').toSingle(ReleaseSourceManager)
 

--- a/Source/prj/main/UnityEditorMenuGenerator.py
+++ b/Source/prj/main/UnityEditorMenuGenerator.py
@@ -1,0 +1,62 @@
+
+from string import Template
+
+from mtm.util.Assert import *
+from mtm.ioc.Inject import Inject
+from mtm.log.Logger import Logger
+
+class UnityEditorMenuGenerator:
+    _schemaLoader = Inject('ProjectSchemaLoader')
+    _sys = Inject('SystemHelper')
+    _log = Inject('Logger')
+
+    _ChangeProjectMenuClassTemplate = Template(
+"""
+using UnityEditor;
+using Projeny.Internal;
+
+namespace Projeny
+{
+    public static class ProjenyChangeProjectMenu
+    {
+        $methods
+    }
+}
+""")
+    
+
+    def Generate(self, currentProjName, currentPlatform, outputPath, allProjectNames):
+        foundCurrent = False
+        methodsText = ""
+        projIndex = 1
+        for projName in allProjectNames:
+            
+            projConfig = self._schemaLoader.loadProjectConfig(projName)
+
+            for platform in projConfig.targetPlatforms:
+                methodsText += """
+        [MenuItem("Projeny/Change Project/{0}-{1}", false, 8)]
+        public static void ChangeProject{2}()""".format(projName, platform, projIndex)
+                methodsText += """
+        {
+            PrjHelper.ChangeProject("{0}", "{1}");
+        }
+        """
+
+                if projName == currentProjName and platform == currentPlatform:
+                    assertThat(not foundCurrent)
+                    foundCurrent = True
+                    methodsText += """
+        [MenuItem("Projeny/Change Project/{0}-{1}", true, 8)]
+        public static bool ChangeProject{2}Validate()""".format(currentProjName, currentPlatform, projIndex)
+                    methodsText += """
+        {
+            return false;
+        }"""
+
+                projIndex += 1
+
+        #assertThat(foundCurrent, "Could not find project " + currentProjName)
+        fileText = self._ChangeProjectMenuClassTemplate.substitute(methods = methodsText)
+        # self._log.info(fileText)
+        self._sys.writeFileAsText(outputPath, fileText)

--- a/Source/prj/main/UnityEditorMenuGenerator.py
+++ b/Source/prj/main/UnityEditorMenuGenerator.py
@@ -23,7 +23,22 @@ namespace Projeny
     }
 }
 """)
+
+    _changeProjectMethodTemplate = Template("""
+        [MenuItem("Projeny/Change Project/$name-$platform", false, 8)]
+        public static void ChangeProject$index()
+        {
+            PrjHelper.ChangeProject("$name", "$platform");
+        }"""
+    )
     
+    _currentProjectMethodTemplate = Template("""
+        [MenuItem("Projeny/Change Project/$name-$platform", true, 8)]
+        public static bool ChangeProject$indexValidate()
+        {
+            return false;
+        }"""
+    )
 
     def Generate(self, currentProjName, currentPlatform, outputPath, allProjectNames):
         foundCurrent = False
@@ -34,25 +49,12 @@ namespace Projeny
             projConfig = self._schemaLoader.loadProjectConfig(projName)
 
             for platform in projConfig.targetPlatforms:
-                methodsText += """
-        [MenuItem("Projeny/Change Project/{0}-{1}", false, 8)]
-        public static void ChangeProject{2}()""".format(projName, platform, projIndex)
-                methodsText += """
-        {
-            PrjHelper.ChangeProject("{0}", "{1}");
-        }
-        """
+                methodsText += self._changeProjectMethodTemplate.substitute(name = projName, platform = platform, index = projIndex)
 
                 if projName == currentProjName and platform == currentPlatform:
                     assertThat(not foundCurrent)
                     foundCurrent = True
-                    methodsText += """
-        [MenuItem("Projeny/Change Project/{0}-{1}", true, 8)]
-        public static bool ChangeProject{2}Validate()""".format(currentProjName, currentPlatform, projIndex)
-                    methodsText += """
-        {
-            return false;
-        }"""
+                    methodsText += _currentProjectMethodTemplate.substitute(name = projName, platform = platform, index = projIndex)
 
                 projIndex += 1
 

--- a/Source/prj/main/UnityEditorMenuGenerator.py
+++ b/Source/prj/main/UnityEditorMenuGenerator.py
@@ -29,15 +29,17 @@ namespace Projeny
         public static void ChangeProject$index()
         {
             PrjHelper.ChangeProject("$name", "$platform");
-        }"""
+        }
+        """
     )
     
     _currentProjectMethodTemplate = Template("""
         [MenuItem("Projeny/Change Project/$name-$platform", true, 8)]
-        public static bool ChangeProject$indexValidate()
+        public static bool ChangeProject${index}Validate()
         {
             return false;
-        }"""
+        }
+        """
     )
 
     def Generate(self, currentProjName, currentPlatform, outputPath, allProjectNames):
@@ -45,8 +47,11 @@ namespace Projeny
         methodsText = ""
         projIndex = 1
         for projName in allProjectNames:
-            
-            projConfig = self._schemaLoader.loadProjectConfig(projName)
+            try:
+                projConfig = self._schemaLoader.loadProjectConfig(projName)
+            except Exception as e:
+                self._log.warn(f'Could not load config for project {projName}. It will not show up in editor menu.')
+                continue
 
             for platform in projConfig.targetPlatforms:
                 methodsText += self._changeProjectMethodTemplate.substitute(name = projName, platform = platform, index = projIndex)
@@ -54,9 +59,10 @@ namespace Projeny
                 if projName == currentProjName and platform == currentPlatform:
                     assertThat(not foundCurrent)
                     foundCurrent = True
-                    methodsText += _currentProjectMethodTemplate.substitute(name = projName, platform = platform, index = projIndex)
+                    methodsText += self._currentProjectMethodTemplate.substitute(name = projName, platform = platform, index = projIndex)
 
                 projIndex += 1
+
 
         #assertThat(foundCurrent, "Could not find project " + currentProjName)
         fileText = self._ChangeProjectMenuClassTemplate.substitute(methods = methodsText)


### PR DESCRIPTION
Projeny init/update links does no longer fails if there is a folder in UnityProjects without a ProjenyProject yaml. This is something which could occur when switching branches in git. See #69. 
Instead it prints a warning and continues as if the faulty project was not there.
