### PR TITLE
Add support for the lumin platform

### DIFF
--- a/Source/mtm/util/PlatformUtil.py
+++ b/Source/mtm/util/PlatformUtil.py
@@ -38,5 +38,8 @@ def fromPlatformArgName(platformArgStr):
     if platformArgStr == 'uwp':
         return Platforms.UWP
 
+    if platformArgStr == 'lumin':
+        return Platforms.Lumin
+
     assertThat(False)
     return ''

--- a/Source/mtm/util/Platforms.py
+++ b/Source/mtm/util/Platforms.py
@@ -7,5 +7,6 @@ class Platforms:
     Linux = 'Linux'
     Ios = 'iOS'
     UWP = 'UWP'
-    All = [Windows, Android, WebGl, OsX, Linux, Ios, UWP]
+    Lumin = 'Lumin'
+    All = [Windows, Android, WebGl, OsX, Linux, Ios, UWP, Lumin]
 

--- a/Source/mtm/util/UnityHelper.py
+++ b/Source/mtm/util/UnityHelper.py
@@ -79,6 +79,9 @@ class UnityHelper:
         if platform == Platforms.UWP:
             return 'wsaplayer'
 
+        if platform == Platforms.Lumin:
+            return 'Lumin'
+
         assertThat(False)
 
     def runEditorFunctionRaw(self, projectName, platform, editorCommand, extraArgs):

--- a/Source/prj/main/Prj.py
+++ b/Source/prj/main/Prj.py
@@ -53,7 +53,7 @@ def addArguments(parser):
     # Core
     parser.add_argument('-in', '--init', action='store_true', help='Initializes the directory links for all projects')
     parser.add_argument('-p', '--project', metavar='PROJECT_NAME', type=str, help="The project to apply changes to.  If unspecified, this will be set to the value for DefaultProject in {0}".format(ConfigFileName))
-    parser.add_argument('-pl', '--platform', type=str, default='win', choices=['w', 'win', 'g', 'webgl', 'a', 'and', 'o', 'osx', 'i', 'ios', 'l', 'lin', 'u', 'uwp'], help='The platform to use.  If unspecified, windows is assumed.')
+    parser.add_argument('-pl', '--platform', type=str, default='win', choices=['w', 'win', 'g', 'webgl', 'a', 'and', 'o', 'osx', 'i', 'ios', 'l', 'lin', 'u', 'uwp', 'lumin'], help='The platform to use.  If unspecified, windows is assumed.')
 
     # Script settinsg
     parser.add_argument('-cfg', '--configPath', metavar='CONFIG_PATH', type=str, help="The path to the _main {0} config file.  If unspecified, it will be assumed to exist at [CurrentDirectory]/{0}".format(ConfigFileName))

--- a/UnityPlugin/Projeny/Main/PrjInterface.cs
+++ b/UnityPlugin/Projeny/Main/PrjInterface.cs
@@ -318,6 +318,8 @@ namespace Projeny
                     return "uwp";
                 }
             }
+            if (platform.ToString() == "Lumin")
+                return "lumin";
 
             throw new NotImplementedException();
         }

--- a/UnityPlugin/Projeny/Main/ProjenyEditorMenu.cs
+++ b/UnityPlugin/Projeny/Main/ProjenyEditorMenu.cs
@@ -120,5 +120,17 @@ namespace Projeny
         {
             PrjHelper.ChangePlatform(BuildTarget.WSAPlayer);
         }
+
+        [MenuItem("Projeny/Change Platform/Lumin", true, 7)]
+        public static bool ChangePlatformLumin_IsValid()
+        {
+            return Enum.IsDefined(typeof(BuildTarget), "Lumin");
+        }
+        [MenuItem("Projeny/Change Platform/Lumin", false, 7)]
+        public static void ChangePlatformLumin()
+        {
+            var lumin = (BuildTarget)Enum.Parse(typeof(BuildTarget), "Lumin");
+            PrjHelper.ChangePlatform(lumin);
+        }
     }
 }

--- a/UnityPlugin/Projeny/Main/ProjenyEditorUtil.cs
+++ b/UnityPlugin/Projeny/Main/ProjenyEditorUtil.cs
@@ -141,6 +141,17 @@ namespace Projeny
                 {
                     return BuildTarget.WSAPlayer;
                 }
+                case "lumin":
+                {
+                    try
+                    {
+                        return (BuildTarget)Enum.Parse(typeof(BuildTarget), "Lumin");
+                    }
+                    catch (ArgumentException)
+                    {
+                        throw new NotImplementedException("Platform not availalble");
+                    }
+                }
             }
 
             throw new NotImplementedException();


### PR DESCRIPTION
There is currently a technical preview build of Unity with support for the lumin SDK. I would like to add it as one of the supported platforms of projeny. Since the lumin target is not yet part of BuildTarget in the standard Unity distribution, I used reflection in order to see if the platform is available.