### PR TITLE
Allow projeny to run even if its installation directory is read only

### DIFF
--- a/Source/mtm/util/SystemHelper.py
+++ b/Source/mtm/util/SystemHelper.py
@@ -17,6 +17,7 @@ import os
 import shlex
 import subprocess
 import shutil
+import stat
 import platform
 from glob import glob
 
@@ -158,6 +159,7 @@ class SystemHelper:
 
         self.makeMissingDirectoriesInPath(toPath)
         shutil.copy2(fromPath, toPath)
+        os.chmod(toPath, stat.S_IWRITE)
 
     def IsDir(self, path):
         return os.path.isdir(self._varManager.expand(path))
@@ -269,6 +271,9 @@ class SystemHelper:
         self._log.debug("Copying directory '{0}' to '{1}'".format(fromPath, toPath))
 
         shutil.copytree(fromPath, toPath)
+        for root, dirs, files in os.walk(toPath):
+            for file in files:
+                os.chmod(os.path.join(root, file), stat.S_IWRITE)
 
     def readFileLines(self, path):
         with self.openInputFile(path) as f:


### PR DESCRIPTION
Currently, Projeny fails to create a project if the Projeny installation directory is made read only. The cause for this is that the files it copies over to the project are also read only. When Projeny then tries to remove them or replace them it gets an Access Denied error.

With these changes, all files which are copied to the project are automatically made writable, solving the above mentioned issues.