### PR TITLE
Add handling of Unity Package Manager folder

### DIFF
--- a/Source/prj/main/PackageManager.py
+++ b/Source/prj/main/PackageManager.py
@@ -107,13 +107,18 @@ class PackageManager:
             else:
                 settingsPath = '[ProjectRoot]/../{0}/ProjectSettings'.format(settingsProject)
 
+            unityPackagesPath = '[ProjectRoot]/UnityPackages'
+            newUnityPackagesDir = os.path.join(projDirPath, 'UnityPackages')
+            self._sys.createDirectory(newUnityPackagesDir)
+
             with self._sys.openOutputFile(os.path.join(projDirPath, ProjectConfigFileName)) as outFile:
                 outFile.write(
 """
 ProjectSettingsPath: '{0}'
+UnityPackagesPath: '{1}'
 #AssetsFolder:
     # Uncomment and Add package names here
-""".format(settingsPath))
+""".format(settingsPath, unityPackagesPath))
 
             self.updateProjectJunctions(projName, platform)
             self.updateLinksForAllProjects()
@@ -308,6 +313,7 @@ ProjectSettingsPath: '{0}'
             self._addGeneratedProjenyFiles('[PluginsDir]/Projeny', schema)
 
         self._junctionHelper.makeJunction(schema.projectSettingsPath, '[ProjectPlatformRoot]/ProjectSettings')
+        self._junctionHelper.makeJunction(schema.unityPackagesPath, '[ProjectPlatformRoot]/Packages')
 
         for packageInfo in schema.packages.values():
 
@@ -446,6 +452,7 @@ ProjectSettingsPath: '{0}'
                 self._log.debug('Created directory "{0}"'.format(self._varMgr.expandPath('[ProjectPlatformRoot]')))
 
                 self._junctionHelper.makeJunction(schema.projectSettingsPath, '[ProjectPlatformRoot]/ProjectSettings')
+                self._junctionHelper.makeJunction(schema.unityPackagesPath, '[ProjectPlatformRoot]/Packages')
 
                 self._updateDirLinksForSchema(schema)
 

--- a/Source/prj/main/ProjectConfig.py
+++ b/Source/prj/main/ProjectConfig.py
@@ -10,3 +10,4 @@ class ProjectConfig:
         self.packageFolders = []
         self.targetPlatforms = []
         self.projectSettingsPath = None
+        self.unityPackagesPath = None

--- a/Source/prj/main/ProjectSchemaLoader.py
+++ b/Source/prj/main/ProjectSchemaLoader.py
@@ -49,6 +49,7 @@ class ProjectSchemaLoader:
         config.solutionFolders = yamlConfig.tryGetOrderedDictionary(OrderedDict(), 'SolutionFolders')
         config.packageFolders = yamlConfig.getList('PackageFolders')
         config.projectSettingsPath = yamlConfig.getString('ProjectSettingsPath')
+        config.unityPackagesPath = yamlConfig.getString('UnityPackagesPath')
 
         # Remove duplicates
         config.assetsFolder = list(set(config.assetsFolder))
@@ -99,7 +100,7 @@ class ProjectSchemaLoader:
 
         self._ensureAllPackagesExist(packageMap)
 
-        return ProjectSchema(name, packageMap, config.solutionFolders, config.projectSettingsPath, platform, config.targetPlatforms)
+        return ProjectSchema(name, packageMap, config.solutionFolders, config.projectSettingsPath, config.unityPackagesPath, platform, config.targetPlatforms)
 
     def _shouldIncludeForPlatform(self, packageName, packageConfig, folderType, platform):
 
@@ -438,11 +439,12 @@ class PackageReference:
         self.sourceDesc = sourceDesc
 
 class ProjectSchema:
-    def __init__(self, name, packages, customFolderMap, projectSettingsPath, platform, targetPlatforms):
+    def __init__(self, name, packages, customFolderMap, projectSettingsPath, unityPackagesPath, platform, targetPlatforms):
         self.name = name
         self.packages = packages
         self.customFolderMap = customFolderMap
         self.projectSettingsPath = projectSettingsPath
+        self.unityPackagesPath = unityPackagesPath
         self.platform = platform
         self.targetPlatforms = targetPlatforms
 

--- a/UnityPlugin/Projeny/Main/Models/ProjectConfig.cs
+++ b/UnityPlugin/Projeny/Main/Models/ProjectConfig.cs
@@ -5,6 +5,7 @@ namespace Projeny
     public class ProjectConfig
     {
         public string ProjectSettingsPath;
+        public string UnityPackagesPath;
         public List<string> AssetsFolder = new List<string>();
         public List<string> PluginsFolder = new List<string>();
         public List<string> SolutionProjects = new List<string>();

--- a/UnityPlugin/Projeny/Main/Serialization/PrjSerializer.cs
+++ b/UnityPlugin/Projeny/Main/Serialization/PrjSerializer.cs
@@ -32,6 +32,7 @@ namespace Projeny.Internal
             return new ProjectConfigInternal()
             {
                 ProjectSettingsPath = info.ProjectSettingsPath,
+                UnityPackagesPath = info.UnityPackagesPath,
                 AssetsFolder = info.AssetsFolder.IsEmpty() ? null : info.AssetsFolder.ToList(),
                 PluginsFolder = info.PluginsFolder.IsEmpty() ? null : info.PluginsFolder.ToList(),
                 SolutionProjects = info.SolutionProjects.IsEmpty() ? null : info.SolutionProjects.ToList(),
@@ -52,6 +53,7 @@ namespace Projeny.Internal
             var newInfo = new ProjectConfig();
 
             newInfo.ProjectSettingsPath = info.ProjectSettingsPath;
+            newInfo.UnityPackagesPath = info.UnityPackagesPath;
 
             if (info.AssetsFolder != null)
             {
@@ -283,6 +285,12 @@ namespace Projeny.Internal
             }
 
             public string ProjectSettingsPath
+            {
+                get;
+                set;
+            }
+
+            public string UnityPackagesPath
             {
                 get;
                 set;

--- a/UnityPlugin/Projeny/PackageManager/Model/PmModel.cs
+++ b/UnityPlugin/Projeny/PackageManager/Model/PmModel.cs
@@ -51,6 +51,9 @@ namespace Projeny.Internal
         string _projectSettingsPath;
 
         [SerializeField]
+        string _unityPackagesPath;
+
+        [SerializeField]
         int _packageFolderIndex;
 
         //Is not used in Unity-plugin, but must be propagated so it is kept in config
@@ -88,6 +91,20 @@ namespace Projeny.Internal
                 _projectSettingsPath = value;
             }
         }
+
+
+        public string UnityPackagesPath
+        {
+            get
+            {
+                return _unityPackagesPath;
+            }
+            set
+            {
+                _unityPackagesPath = value;
+            }
+        }
+
 
         public IEnumerable<ReleaseInfo> Releases
         {

--- a/UnityPlugin/Projeny/PackageManager/Model/PmProjectHandler.cs
+++ b/UnityPlugin/Projeny/PackageManager/Model/PmProjectHandler.cs
@@ -33,6 +33,7 @@ namespace Projeny.Internal
             var config = new ProjectConfig();
 
             config.ProjectSettingsPath = _model.ProjectSettingsPath;
+            config.UnityPackagesPath = _model.UnityPackagesPath;
 
             config.AssetsFolder.AddRange(_model.AssetItems);
             config.PluginsFolder.AddRange(_model.PluginItems);
@@ -60,6 +61,7 @@ namespace Projeny.Internal
         public void ResetProject()
         {
             _model.ProjectSettingsPath = null;
+            _model.UnityPackagesPath = null;
             _model.ClearAssetItems();
             _model.ClearPluginItems();
         }
@@ -150,6 +152,7 @@ namespace Projeny.Internal
         void PopulateModelFromConfig(ProjectConfig config)
         {
             _model.ProjectSettingsPath = config.ProjectSettingsPath;
+            _model.UnityPackagesPath = config.UnityPackagesPath;
 
             _model.ClearPluginItems();
             foreach (var name in config.PluginsFolder)


### PR DESCRIPTION
Currently, the Unity Package Manager folder, located at "[ProjectRoot]"/Packages, is not handled by Projeny, which cause issues when adding a custom package to a multi-platform project, or when using source control.

With this change, the folder is handled the same way as the "ProjectSettings" folder: a single folder "Unitypackage" is created in the common project root, and linked into each platform.

This way, the manifest file is correctly shared between platforms and saved in source control.